### PR TITLE
feat: add global notice banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import GlobalNotice from "@/components/GlobalNotice";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <GlobalNotice />
         {children}
       </body>
     </html>

--- a/src/components/GlobalNotice.tsx
+++ b/src/components/GlobalNotice.tsx
@@ -1,0 +1,17 @@
+import { AlertTriangle } from "lucide-react";
+
+export default function GlobalNotice() {
+  return (
+    <div
+      className="w-full bg-gray-100 text-gray-800 text-sm py-2 px-4 flex items-center justify-center gap-2"
+      role="status"
+      aria-live="polite"
+    >
+      <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+      <p>
+        Hinweis: Dieses Dialog-Interface befindet sich noch in der Entwicklung. Es können Fehler oder unnatürliche
+        Antworten auftreten.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add GlobalNotice component displaying development notice banner
- include GlobalNotice in root layout to show banner on every page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:check`
- `npm run type-check`
- `GROQ_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3909b901c8326941add27e63dd63a