### PR TITLE
feat: add simple RAG retrieval

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,13 +1,19 @@
 // src/app/api/chat/route.ts - FIXED MIT LLM
 import { NextRequest, NextResponse } from 'next/server'
 import { callLLM } from '@/lib/llm'
+import { retrieve } from '@/lib/rag'
 
 export async function POST(request: NextRequest) {
   try {
     const { message, context, formValues } = await request.json()
     
     console.log('💬 Chat API called:', { message, hasContext: !!context })
-    
+
+    const ragResults = await retrieve(message)
+    const ragContext = ragResults
+      .map(r => `Quelle: ${r.source}\n${r.text}`)
+      .join('\n\n')
+
     // Kontext für bessere LLM-Antworten aufbauen
     const enhancedContext = `
 FORMULAR-KONTEXT: Gebäude-Energieberatung für Mehrfamilienhaus
@@ -18,6 +24,9 @@ ${formValues ? Object.entries(formValues)
   .filter(([key, value]) => value && String(value).trim())
   .map(([key, value]) => `- ${key}: ${value}`)
   .join('\n') : 'Noch keine Felder ausgefüllt'}
+
+RAG-KONTEXT:
+${ragContext || 'Keine zusätzlichen Informationen gefunden.'}
 
 NUTZER-FRAGE: ${message}
 

--- a/src/lib/rag.ts
+++ b/src/lib/rag.ts
@@ -1,0 +1,39 @@
+import { promises as fs } from 'fs'
+
+interface RagChunk {
+  text: string
+  source: string
+}
+
+function tokenize(str: string): string[] {
+  return str.toLowerCase().split(/\W+/).filter(Boolean)
+}
+
+export async function retrieve(query: string, k = 5): Promise<RagChunk[]> {
+  const possiblePaths = ['data/rag-index.json', 'data/rag-index']
+  let raw: string | null = null
+
+  for (const p of possiblePaths) {
+    try {
+      raw = await fs.readFile(p, 'utf8')
+      break
+    } catch {
+      continue
+    }
+  }
+
+  if (!raw) return []
+
+  const index: RagChunk[] = JSON.parse(raw)
+  const tokens = tokenize(query)
+
+  const scored = index
+    .map(chunk => {
+      const chunkTokens = tokenize(chunk.text)
+      const overlap = tokens.filter(t => chunkTokens.includes(t)).length
+      return { ...chunk, score: overlap }
+    })
+    .sort((a, b) => b.score - a.score)
+
+  return scored.slice(0, k).map(({ text, source }) => ({ text, source }))
+}


### PR DESCRIPTION
## Summary
- implement simple retrieval to load and score RAG index
- augment chat API with retrieved context

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68afffebe74883268ad34a96db3aa141