### PR TITLE
Add landing navigation and variants testing page

### DIFF
--- a/src/app/variants/page.tsx
+++ b/src/app/variants/page.tsx
@@ -1,17 +1,17 @@
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 
-export default function HomePage() {
+export default function VariantsPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
       <div className="text-center space-y-6">
-        <h1 className="text-3xl font-bold text-gray-800">FormularIQ Studie</h1>
+        <h1 className="text-3xl font-bold text-gray-800">Varianten testen</h1>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Button asChild>
-            <Link href="/study">Studie starten</Link>
+            <Link href="/form-a">Variante A</Link>
           </Button>
-          <Button asChild variant="secondary">
-            <Link href="/variants">Varianten testen</Link>
+          <Button asChild>
+            <Link href="/form-b">Variante B</Link>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace automatic redirect with homepage buttons for study and variants
- Add `/variants` page offering navigation to form A and B

## Testing
- `npm run lint`
- `npm run type-check`
- `GROQ_API_KEY=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b00f08ccf48326bfe05c2ed7f21f00